### PR TITLE
Add raw HTML test

### DIFF
--- a/test.js
+++ b/test.js
@@ -186,6 +186,8 @@ test('remark-slug', function (t) {
         '## :ok_hand::hatched_chick: Two in a row with no spaces',
         '',
         '## :ok_hand: :hatched_chick: Two in a row',
+        '',
+        '## <my package>-tests.ts',
         ''
       ].join('\n')
     ),
@@ -212,7 +214,8 @@ test('remark-slug', function (t) {
       heading(
         ':ok_hand: :hatched_chick: Two in a row',
         'ok_hand-hatched_chick-two-in-a-row'
-      )
+      ),
+      heading('-tests.ts', '-teststs')
     ]),
     'should create GitHub slugs'
   )


### PR DESCRIPTION
remark-validate-links failed to catch a mistake featuring this heading because remark-slug produces one slug while GitHub actually produces another.

Here's a link to the mistaken revision in which I neglected escapes and remark-validate-links failed to catch the consequent broken links: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/eee07ad6739c7d50a22d5a8a72763f326279e0a5/README.md#-teststs