### PR TITLE
Option to enable unique slugs across files or trees.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,20 +3,32 @@
  * @typedef {import('hast').Properties} Properties
  */
 
+import BananaSlug from 'github-slugger'
 import {toString} from 'mdast-util-to-string'
 import {visit} from 'unist-util-visit'
-import BananaSlug from 'github-slugger'
 
 const slugs = new BananaSlug()
 
 /**
  * Plugin to add anchors headings using GitHub’s algorithm.
  *
- * @type {import('unified').Plugin<void[], Root>}
+ * @type {import('unified').Plugin<[object?]|void[], Root>}
+ *
+ * @param {object} options
+ * @param {boolean} [options.multifile] - The plugin maintains an internal state
+ *     of slugs with a counter to deduplicate slugs for headings that exist more
+ *     than once. By default this counter state is specific to a file or syntax
+ *     tree. Use 'multifile: true' if you need to count slugs across files or
+ *     trees. Call remarkSlug() explicitly to reset the state.
  */
-export default function remarkSlug() {
+export default function remarkSlug(options = {}) {
+  const {multifile} = {multifile: false, ...options}
+
+  slugs.reset()
   return (tree) => {
-    slugs.reset()
+    if (!multifile) {
+      slugs.reset()
+    }
 
     visit(tree, 'heading', (node) => {
       const data = node.data || (node.data = {})


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Closes #20 . Making remark-slug configurable. Introducing an option to keep slug counter state across files.

<!--do not edit: pr-->
